### PR TITLE
Use the same font for all the components

### DIFF
--- a/Components/Input.qml
+++ b/Components/Input.qml
@@ -297,6 +297,7 @@ Column {
                 anchors.left: indicator.right
                 anchors.leftMargin: indicator.width / 2
                 font.pointSize: root.font.pointSize * 0.8
+                font.family: root.font.family
                 color: root.palette.text
             }
 
@@ -452,6 +453,7 @@ Column {
                 text: parent.text
                 color: config.OverrideLoginButtonTextColor != "" ? config.OverrideLoginButtonTextColor : root.palette.highlight.hslLightness >= 0.7 ? "#444" : "white"
                 font.pointSize: root.font.pointSize
+                font.family: root.font.family
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
                 opacity: 0.5

--- a/Components/SessionButton.qml
+++ b/Components/SessionButton.qml
@@ -51,6 +51,7 @@ Item {
             contentItem: Text {
                 text: model.name
                 font.pointSize: root.font.pointSize * 0.8
+                font.family: root.font.family
                 color: selectSession.highlightedIndex === index ? root.palette.highlight.hslLightness >= 0.7 ? "#444444" : "white" : root.palette.window.hslLightness >= 0.8 ? root.palette.highlight.hslLightness >= 0.8 ? "#444444" : root.palette.highlight : "white"
                 verticalAlignment: Text.AlignVCenter
                 horizontalAlignment: Text.AlignHCenter
@@ -73,6 +74,7 @@ Item {
             anchors.left: parent.left
             anchors.leftMargin: 3
             font.pointSize: root.font.pointSize * 0.8
+            font.family: root.font.family
             Keys.onReleased: parent.popup.open()
         }
 


### PR DESCRIPTION
This will use the font set in `theme.conf` consistently across UI components.

Before:
![image](https://user-images.githubusercontent.com/56920956/203312588-51154b7d-d3d0-432c-82ad-e8bc3a90535b.png)

After:
![image](https://user-images.githubusercontent.com/56920956/203312366-582b28b2-4042-4dd0-9023-574927539a52.png)

Don't really know how QML works so not sure whether this was the best way to implement this.