### PR TITLE
Add umask commands with default value 022

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -34,12 +34,14 @@ install_dependencies(){
 }
 
 git_clone(){
+    umask 022
     echo -e "${green}[*] Cloning theme to $path_to_git_clone.${no_color}"
     [ -d "$path_to_git_clone"/sddm-astronaut-theme ] && sudo mv "$path_to_git_clone"/sddm-astronaut-theme "$path_to_git_clone"/sddm-astronaut-theme_$date && echo -e "${green}[*] Old configs detected in $path_to_git_clone, backing up.${no_color}"
     git clone -b master --depth 1 https://github.com/keyitdev/sddm-astronaut-theme.git "$path_to_git_clone"/sddm-astronaut-theme
 }
 
 copy_files(){
+    umask 022
     echo -e "${green}[*] Coping theme from $path_to_git_clone to /usr/share/sddm/themes/.${no_color}"
     [ -d /usr/share/sddm/themes/sddm-astronaut-theme ] && sudo mv /usr/share/sddm/themes/sddm-astronaut-theme /usr/share/sddm/themes/sddm-astronaut-theme_$date && echo -e "${green}[*] Old configs detected in /usr/share/sddm/themes/sddm-astronaut-theme, backing up.${no_color}"
     sudo mkdir -p /usr/share/sddm/themes/sddm-astronaut-theme


### PR DESCRIPTION
This is done to make sure the sddm theme folder gets the correct permissions for sddm to be able to read it.

Users with custom `umask` commands in their .bashrc may suffer permission denials otherwise.

![image](https://github.com/user-attachments/assets/b0cbd201-877e-49a0-8739-5dfae57ad9f6)


_Thank you for the cool theme._