### PR TITLE
Fix shebang

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ## Keyitdev https://github.com/Keyitdev/sddm-astronaut-theme
 ## Copyright (C) 2022-2025 Keyitdev


### PR DESCRIPTION
The setup.sh script appears to use some non-posix compliant syntax. Specifically $(("new_number")) in line 80 resulted in an error when using dash as /bin/sh. This commit therefore updates the shebang to use /bin/bash instead.