### PR TITLE
Implement support for User Avatars

### DIFF
--- a/Components/UserAvatar.qml
+++ b/Components/UserAvatar.qml
@@ -1,0 +1,74 @@
+// Config created by Noctua & Keyitdev https://github.com/Keyitdev/sddm-astronaut-theme
+// Copyright (C) 2022-2025 Keyitdev
+// Based on https://github.com/MarianArlt/sddm-sugar-dark
+// Distributed under the GPLv3+ License https://www.gnu.org/licenses/gpl-3.0.html
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import SddmComponents 2.0 as SDDM
+
+Item {
+    id: avatarBlock
+    property real inputWidth: 100  // Will be overridden by parent
+    width: inputWidth
+
+    Component.onCompleted: {
+        if (userPicture.enabled) {
+            userPicture.source = userWrapper.items.get(userList.currentIndex).model.icon;
+        }
+    }
+
+    DelegateModel {
+        id: userWrapper
+        model: userModel
+
+        delegate: ItemDelegate {
+            id: userEntry
+            highlighted: userList.currentIndex === index
+        }
+    }
+
+    ListView {
+        id: userList
+        implicitHeight: contentHeight
+        spacing: 8
+        model: userWrapper
+        currentIndex: userModel.lastIndex
+        clip: true
+    }
+
+    Item {
+        Layout.alignment: Qt.AlignHCenter
+        width: inputWidth
+        implicitHeight: pictureBorder.height
+
+        Rectangle {
+            id: pictureBorder
+            anchors.centerIn: userPicture
+            height: inputWidth / 1.5 + (border.width * 2)
+            width: inputWidth / 1.5 + (border.width * 2)
+            //radius: height / 2 // Circle avatar
+            radius: 1 // Square avatar
+            border.width: config.UserBorderWidth
+            border.color: config.UserBorderColor
+            color: config.UserColor
+        }
+
+        Image {
+            id: userPicture
+            source: ""
+            height: inputWidth / 1.5
+            width: inputWidth / 1.5
+            anchors.horizontalCenter: parent.horizontalCenter
+            fillMode: Image.PreserveAspectCrop
+            layer.enabled: true
+
+            Rectangle {
+                anchors.fill: parent
+                radius: inputWidth / 3
+                visible: false
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello @Keyitdev , I implemented the support for user avatar.

By the current code, if the system has more than one user, I think the avatar of the last logged user will be shown.

Furthermore, I tried to implement the avatar image as a circle. I can only set the border object as a circle but the avatar image itself remains as a square, and currently I don't know how to fix it. In Qt5 it could be fixed by using QtGraphicalEffects that has been dropped in Qt6, so another solution must be found.

Inside the config of each theme, the following variables should be set:
```
#################### User Picture ####################

UserPictureEnabled="true"
UserBorderColor="#b4befe"
UserBorderWidth=5
UserColor="#cdd6f4"
Scale=1
```

Here some examples of the output:

![image](https://github.com/user-attachments/assets/98395636-d181-4e2d-a0dc-9250b84279f0)

![image](https://github.com/user-attachments/assets/0f6aca82-66ba-4db1-ab34-281e4677fa47)

![image](https://github.com/user-attachments/assets/625c635e-5ee3-476e-a64b-e23cb9e66ee6)

![image](https://github.com/user-attachments/assets/13103471-800d-4860-9e85-d526f8a2310a)

![image](https://github.com/user-attachments/assets/4e39e822-df95-46eb-acbc-258c2e223262)

![image](https://github.com/user-attachments/assets/96bb06e7-7ad6-4918-a058-b31591ab2a36)

![image](https://github.com/user-attachments/assets/bddf04fe-fdab-4fff-8d52-66f059c0aa75)

If you have an idea on how to implement also a circled avatar image, would be wonderful.

Let me know also if the case of multiple users is good as is.