### PR TITLE
README.md: Added Installation Instructions for NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,46 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/keyitdev/sddm-astronaut-
 > Works on distributions using pacman, xbps-install, dnf, zypper.   
 > Remember to always read the scripts you run from the internet.
 
-### Manual Installation
+### NixOS Installation
+
+#### Using System Configuration with Custom Overrides
+
+While not officially packaged by the upstream maintainers, there is a [community-maintained package](https://search.nixos.org/packages?channel=unstable&query=sddm-astronaut#show=sddm-astronaut) maintained by @DaniD3v, @uxodb, and @qweered. You can install and customize the theme by creating an override of the package in your `configuration.nix`:
+
+```nix
+let
+  sddm-astronaut = (pkgs.sddm-astronaut.override {
+    embeddedTheme = "japanese_aesthetic";  # or any other theme
+    themeConfig = {
+      # Customize colors and settings
+      HeaderTextColor = "#d5c4a1";
+      Background = "Backgrounds/your-custom-background.png";
+      # ... other theme configuration options
+    };
+  }).overrideAttrs (oldAttrs: {
+    # Optional: Inject custom background image
+    installPhase = oldAttrs.installPhase + ''
+      chmod u+w $out/share/sddm/themes/sddm-astronaut-theme/Backgrounds/
+      cp ${./relative/path/to/your-custom-background.png} \
+        $out/share/sddm/themes/sddm-astronaut-theme/Backgrounds/your-custom-background.png
+    '';
+  });
+in
+{
+  environment.systemPackages = [ sddm-astronaut ];
+  
+  services.displayManager.sddm = {
+    enable = true;
+    package = pkgs.kdePackages.sddm;
+    extraPackages = with pkgs; [
+      kdePackages.qtmultimedia # Required for video backgrounds/audio
+    ];
+    theme = "sddm-astronaut-theme";
+  };
+}
+```
+
+## Manual Installation
 
 1. Install **dependencies**
 


### PR DESCRIPTION
Regarding the issue #84, I added some small instructions for installation and configuration of `sddm-astronaut` in NixOS, as promised. I hope it is helpful. 